### PR TITLE
Update action to Node v14

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: true
     description: 'Local directory to be published as a static site'
 runs:
-  using: 'node12'
+  using: 'node14'
   main: 'dist/index.js'
 branding:
   icon: 'upload-cloud'


### PR DESCRIPTION
Would like to update the action to Node.js 14 to resolve an error originating from the `SiteCertCertificateRequestorFunction`.

Please check out the [failed deployment](https://github.com/onramper/widget/runs/4344589605) of the Onramper widget for more information about the error. Note: this regards a deployment to a new subdomain, which might be the reason why this hasn't occured before.

See the following links for more information about the Node.js versions:
* [AWS - Recommended Lambda runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)
* [Node.js - Releases](https://nodejs.org/en/about/releases/)
* [AWS - AWS CDK prerequisites](https://docs.aws.amazon.com/cdk/latest/guide/work-with.html#work-with-prerequisites)